### PR TITLE
Use Environment for LLMEvaluator

### DIFF
--- a/fullmoon/ContentView.swift
+++ b/fullmoon/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     private var idiom : UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     @EnvironmentObject var appManager: AppManager
     @Environment(\.modelContext) var modelContext
-    @EnvironmentObject var llm: LLMEvaluator
+    @Environment(LLMEvaluator.self) var llm
     @State var showOnboarding = false
     @State var showSettings = false
     @State var showChats = false

--- a/fullmoon/Models/LLMEvaluator.swift
+++ b/fullmoon/Models/LLMEvaluator.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 @Observable
 @MainActor
-class LLMEvaluator: ObservableObject {
+class LLMEvaluator {
     var running = false
     var output = ""
     var modelInfo = ""

--- a/fullmoon/Views/Onboarding/OnboardingDownloadingModelProgressView.swift
+++ b/fullmoon/Views/Onboarding/OnboardingDownloadingModelProgressView.swift
@@ -12,7 +12,7 @@ struct OnboardingDownloadingModelProgressView: View {
     @Binding var showOnboarding: Bool
     @EnvironmentObject var appManager: AppManager
     @Binding var selectedModel: ModelConfiguration
-    @EnvironmentObject var llm: LLMEvaluator
+    @Environment(LLMEvaluator.self) var llm
     @State var installed = false
     
     let moonPhases = [

--- a/fullmoon/Views/Settings/ModelsSettingsView.swift
+++ b/fullmoon/Views/Settings/ModelsSettingsView.swift
@@ -10,7 +10,7 @@ import MLXLLM
 
 struct ModelsSettingsView: View {
     @EnvironmentObject var appManager: AppManager
-    @EnvironmentObject var llm: LLMEvaluator
+    @Environment(LLMEvaluator.self) var llm
     @State var showOnboardingInstallModelView = false
     
     var body: some View {

--- a/fullmoon/Views/Settings/SettingsView.swift
+++ b/fullmoon/Views/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var appManager: AppManager
     @Environment(\.dismiss) var dismiss
-    @EnvironmentObject var llm: LLMEvaluator
+    @Environment(LLMEvaluator.self) var llm
     @Binding var currentThread: Thread?
     
     var body: some View {

--- a/fullmoon/fullmoonApp.swift
+++ b/fullmoon/fullmoonApp.swift
@@ -11,7 +11,7 @@ import MLXLLM
 @main
 struct fullmoonApp: App {
     @StateObject var appManager = AppManager()
-    @StateObject var llm = LLMEvaluator()
+    @State var llm = LLMEvaluator()
     
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Congrats, and I'm really enjoying fullmoon! I love the way it's put together and my initial experience with it has been great. 

This is just a simple PR to clean up `LLMEvaluator` which doesn't need to be an `ObservableObject` since it's already `Observable`. I tested these changes locally and you should find the behavior to be unchanged.

Perhaps there was more to this and something that I may have missed! I didn't touch `AppManager` since it seems to be using `didSet` which I don't believe is compatible with `Observable`.