### PR TITLE
Add Increased Memory Limit Entitlement

### DIFF
--- a/fullmoon/fullmoon.entitlements
+++ b/fullmoon/fullmoon.entitlements
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.developer.kernel.increased-debugging-memory-limit</key>
+	<true/>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds Increased Memory Limit Entitlement to squeeze some more performance out, the MLX buffer cache can also be increased if needed. Might need to do some finagling with provisioning profiles.