### PR TITLE
Add space below the search bar on mac

### DIFF
--- a/fullmoon/Views/Chat/ChatsListView.swift
+++ b/fullmoon/Views/Chat/ChatsListView.swift
@@ -22,6 +22,9 @@ struct ChatsListView: View {
         NavigationStack {
             ZStack {
                 List(selection: $selection) {
+                    #if os(macOS)
+                    Section {} // adds some space below the search bar on mac
+                    #endif
                     ForEach(filteredThreads) { thread in
                         VStack(alignment: .leading) {
                             Group {


### PR DESCRIPTION
- added some space under the search bar on mac

**before**
<img src="https://github.com/user-attachments/assets/61d71de6-a295-4e94-9af0-38555f03cd3e" width="256px" />

**after**
<img src="https://github.com/user-attachments/assets/9223d175-b773-4124-a77c-dc07fcd09477" width="256px" />