### PR TITLE
Fix corner radius of chat input and messages

### DIFF
--- a/fullmoon/Views/Chat/ChatView.swift
+++ b/fullmoon/Views/Chat/ChatView.swift
@@ -33,7 +33,11 @@ struct ChatView: View {
             TextField("message", text: $prompt, axis: .vertical)
                 .focused($isPromptFocused)
                 .textFieldStyle(.plain)
-                .padding(.horizontal)
+            #if os(iOS)
+                .padding(.horizontal, 16)
+            #elseif os(macOS)
+                .padding(.horizontal, 12)
+            #endif
                 .if(appManager.userInterfaceIdiom == .pad || appManager.userInterfaceIdiom == .mac) { view in
                     view
                         .onSubmit {
@@ -54,10 +58,17 @@ struct ChatView: View {
                 generateButton
             }
         }
+        #if os(iOS)
         .background(
             RoundedRectangle(cornerRadius: 24)
                 .fill(platformBackgroundColor)
         )
+        #elseif os(macOS)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(platformBackgroundColor)
+        )
+        #endif
     }
 
     var modelPickerButton: some View {
@@ -156,10 +167,19 @@ struct ChatView: View {
                 .textSelection(.enabled)
                 .if(message.role == .user) { view in
                     view
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .background(platformBackgroundColor)
+                    #if os(iOS)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    #else
+                    .padding(.horizontal, 16 * 2 / 3)
+                    .padding(.vertical, 8)
+                    #endif
+                    .background(platformBackgroundColor)
+                    #if os(iOS)
                         .mask(RoundedRectangle(cornerRadius: 24))
+                    #elseif os(macOS)
+                        .mask(RoundedRectangle(cornerRadius: 16))
+                    #endif
                 }
                 .padding(message.role == .user ? .leading : .trailing, 48)
             if message.role == .assistant { Spacer() }


### PR DESCRIPTION
- fixed padding and corner radius of chat input (to fit with the send button)
- fixed padding and corner radius of messages (to fit with the new chat input)

both changes are for mac only

**before**
<img src="https://github.com/user-attachments/assets/470fbf30-5471-4f93-a9e4-8bf08584da72" width="50%"/>


**after**
<img src="https://github.com/user-attachments/assets/a1790255-e835-4a9f-890b-ea80c95d8aa1" width="50%"/>
