### PR TITLE
Add icon to credits section in settings

### DIFF
--- a/fullmoon/Views/Settings/SettingsView.swift
+++ b/fullmoon/Views/Settings/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
                 
                 Section {
                     NavigationLink(destination: CreditsView()) {
-                        Text("credits")
+                        Label("credits", systemImage: "shippingbox")
                     }
                 }
                 


### PR DESCRIPTION
Add icon to credits section in settings, without icon on macOS its hard to tell that the view is able to be tapped on. 

| Before  | After |
| ------------- | ------------- |
| <img width="472" alt="BeforeFixMacos" src="https://github.com/user-attachments/assets/1e74a9c7-04d3-4a8c-8e44-225a7a786057" />  | <img width="472" alt="afterFixMacos" src="https://github.com/user-attachments/assets/a215850b-3614-4379-b338-b332a46f0263" /> |


