### PR TITLE
[MFE-112] fix output when changing thread

### DIFF
--- a/fullmoon/Views/Chat/ChatView.swift
+++ b/fullmoon/Views/Chat/ChatView.swift
@@ -25,7 +25,7 @@ struct ChatView: View {
     }
 
     let platformBackgroundColor: Color = {
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         return Color(UIColor.secondarySystemBackground)
         #elseif os(visionOS)
         return Color(UIColor.separator)

--- a/fullmoon/Views/Chat/ChatView.swift
+++ b/fullmoon/Views/Chat/ChatView.swift
@@ -19,6 +19,8 @@ struct ChatView: View {
     @FocusState.Binding var isPromptFocused: Bool
     @Binding var showChats: Bool
     @Binding var showSettings: Bool
+    
+    @State private var generatingThread: Thread?
 
     var isPromptEmpty: Bool {
         prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -174,7 +176,7 @@ struct ChatView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 if let currentThread = currentThread {
-                    ConversationView(thread: currentThread)
+                    ConversationView(thread: currentThread, generatingThread: generatingThread)
                 } else {
                     Spacer()
                     Image(systemName: appManager.getMoonPhaseIcon())
@@ -270,6 +272,7 @@ struct ChatView: View {
             }
 
             if let currentThread = currentThread {
+                generatingThread = currentThread
                 Task {
                     let message = prompt
                     prompt = ""
@@ -279,6 +282,7 @@ struct ChatView: View {
                     if let modelName = appManager.currentModelName {
                         let output = await llm.generate(modelName: modelName, thread: currentThread, systemPrompt: appManager.systemPrompt)
                         sendMessage(Message(role: .assistant, content: output, thread: currentThread))
+                        generatingThread = nil
                     }
                 }
             }

--- a/fullmoon/Views/Chat/ChatView.swift
+++ b/fullmoon/Views/Chat/ChatView.swift
@@ -20,14 +20,14 @@ struct ChatView: View {
     @Binding var showChats: Bool
     @Binding var showSettings: Bool
     
-    @State private var generatingThread: Thread?
+    @State private var generatingThreadID: UUID?
 
     var isPromptEmpty: Bool {
         prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     let platformBackgroundColor: Color = {
-        #if os(iOS) || os(visionOS)
+        #if os(iOS)
         return Color(UIColor.secondarySystemBackground)
         #elseif os(visionOS)
         return Color(UIColor.separator)
@@ -176,7 +176,7 @@ struct ChatView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 if let currentThread = currentThread {
-                    ConversationView(thread: currentThread, generatingThread: generatingThread)
+                    ConversationView(thread: currentThread, generatingThreadID: generatingThreadID)
                 } else {
                     Spacer()
                     Image(systemName: appManager.getMoonPhaseIcon())
@@ -272,7 +272,7 @@ struct ChatView: View {
             }
 
             if let currentThread = currentThread {
-                generatingThread = currentThread
+                generatingThreadID = currentThread.id
                 Task {
                     let message = prompt
                     prompt = ""
@@ -282,7 +282,7 @@ struct ChatView: View {
                     if let modelName = appManager.currentModelName {
                         let output = await llm.generate(modelName: modelName, thread: currentThread, systemPrompt: appManager.systemPrompt)
                         sendMessage(Message(role: .assistant, content: output, thread: currentThread))
-                        generatingThread = nil
+                        generatingThreadID = nil
                     }
                 }
             }

--- a/fullmoon/Views/Chat/ConversationView.swift
+++ b/fullmoon/Views/Chat/ConversationView.swift
@@ -52,7 +52,7 @@ struct ConversationView: View {
     @Environment(LLMEvaluator.self) var llm
     @EnvironmentObject var appManager: AppManager
     let thread: Thread
-    let generatingThread: Thread?
+    let generatingThreadID: UUID?
 
     @State private var scrollID: String?
     @State private var scrollInterrupted = false
@@ -67,7 +67,7 @@ struct ConversationView: View {
                             .id(message.id.uuidString)
                     }
 
-                    if llm.running && !llm.output.isEmpty && thread == generatingThread {
+                    if llm.running && !llm.output.isEmpty && thread.id == generatingThreadID {
                         MessageView(message: Message(role: .assistant, content: llm.output + " 🌕"))
                             .padding()
                             .id("output")
@@ -108,7 +108,7 @@ struct ConversationView: View {
 }
 
 #Preview {
-    ConversationView(thread: Thread(), generatingThread: nil)
+    ConversationView(thread: Thread(), generatingThreadID: nil)
         .environment(LLMEvaluator())
         .environmentObject(AppManager())
 }

--- a/fullmoon/Views/Chat/ConversationView.swift
+++ b/fullmoon/Views/Chat/ConversationView.swift
@@ -52,6 +52,7 @@ struct ConversationView: View {
     @Environment(LLMEvaluator.self) var llm
     @EnvironmentObject var appManager: AppManager
     let thread: Thread
+    let generatingThread: Thread?
 
     @State private var scrollID: String?
     @State private var scrollInterrupted = false
@@ -66,7 +67,7 @@ struct ConversationView: View {
                             .id(message.id.uuidString)
                     }
 
-                    if llm.running && !llm.output.isEmpty {
+                    if llm.running && !llm.output.isEmpty && thread == generatingThread {
                         MessageView(message: Message(role: .assistant, content: llm.output + " 🌕"))
                             .padding()
                             .id("output")
@@ -107,7 +108,7 @@ struct ConversationView: View {
 }
 
 #Preview {
-    ConversationView(thread: Thread())
+    ConversationView(thread: Thread(), generatingThread: nil)
         .environment(LLMEvaluator())
         .environmentObject(AppManager())
 }

--- a/fullmoon/Views/Chat/ConversationView.swift
+++ b/fullmoon/Views/Chat/ConversationView.swift
@@ -38,7 +38,7 @@ struct MessageView: View {
     }
 
     let platformBackgroundColor: Color = {
-        #if os(iOS) || os(visionOS)
+        #if os(iOS)
         return Color(UIColor.secondarySystemBackground)
         #elseif os(visionOS)
         return Color(UIColor.separator)

--- a/fullmoon/Views/Chat/ConversationView.swift
+++ b/fullmoon/Views/Chat/ConversationView.swift
@@ -38,7 +38,7 @@ struct MessageView: View {
     }
 
     let platformBackgroundColor: Color = {
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         return Color(UIColor.secondarySystemBackground)
         #elseif os(visionOS)
         return Color(UIColor.separator)


### PR DESCRIPTION
- add a check to make generating output thread specific
- this fixes an issue where changing conversation while an output is being generated would make the output appear in the new conversation