### PR TITLE
[MFE-203] Add a number of visits between each review request

### DIFF
--- a/fullmoon/Models/Data.swift
+++ b/fullmoon/Models/Data.swift
@@ -17,6 +17,7 @@ class AppManager: ObservableObject {
     @AppStorage("currentModelName") var currentModelName: String?
     @AppStorage("shouldPlayHaptics") var shouldPlayHaptics = true
     @AppStorage("numberOfVisits") var numberOfVisits = 0
+    @AppStorage("numberOfVisitsOfLastRequest") var numberOfVisitsOfLastRequest = 0
     
     var userInterfaceIdiom: LayoutType {
         #if os(visionOS)

--- a/fullmoon/Views/Chat/ChatsListView.swift
+++ b/fullmoon/Views/Chat/ChatsListView.swift
@@ -143,8 +143,9 @@ struct ChatsListView: View {
     }
 
     func requestReviewIfAppropriate() {
-        if appManager.numberOfVisits >= 5 {
+        if appManager.numberOfVisits - appManager.numberOfVisitsOfLastRequest >= 5 {
             requestReview() // can only be prompted if the user hasn't given a review in the last year, so it will prompt again when apple deems appropriate
+            appManager.numberOfVisitsOfLastRequest = appManager.numberOfVisits
         }
     }
 


### PR DESCRIPTION
This prevents the review prompt from being shown back to back when the user refuses to leave a review. Instead of checking if the user has at least 5 app visits in total, it checks if the user has at least 5 visits since the last time they were prompted to leave a review.