### PR TITLE
[MFE-234] Update app intent system prompt

### DIFF
--- a/fullmoon/Models/Data.swift
+++ b/fullmoon/Models/Data.swift
@@ -150,7 +150,7 @@ class Message {
 }
 
 @Model
-class Thread {
+final class Thread: Sendable {
     @Attribute(.unique) var id: UUID
     var title: String?
     var timestamp: Date

--- a/fullmoon/Models/LLMEvaluator.swift
+++ b/fullmoon/Models/LLMEvaluator.swift
@@ -11,6 +11,10 @@ import MLXLMCommon
 import MLXRandom
 import SwiftUI
 
+enum LLMEvaluatorError: Error {
+    case modelNotFound(String)
+}
+
 @Observable
 @MainActor
 class LLMEvaluator {
@@ -49,14 +53,16 @@ class LLMEvaluator {
     /// load and return the model -- can be called multiple times, subsequent calls will
     /// just return the loaded model
     func load(modelName: String) async throws -> ModelContainer {
-        let model = ModelConfiguration.getModelByName(modelName)
+        guard let model = ModelConfiguration.getModelByName(modelName) else {
+            throw LLMEvaluatorError.modelNotFound(modelName)
+        }
         
         switch loadState {
         case .idle:
             // limit the buffer cache
             MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
 
-            let modelContainer = try await LLMModelFactory.shared.loadContainer(configuration: model!)
+            let modelContainer = try await LLMModelFactory.shared.loadContainer(configuration: model)
             {
                 [modelConfiguration] progress in
                 Task { @MainActor in

--- a/fullmoon/Models/RequestLLMIntent.swift
+++ b/fullmoon/Models/RequestLLMIntent.swift
@@ -7,7 +7,7 @@ struct RequestLLMIntent: AppIntent {
     static var title: LocalizedStringResource = "new chat"
     static var description: LocalizedStringResource = "start a new chat"
     
-    @Parameter(title: "continuous chat", default: true)
+    @Parameter(title: "Continuous Chat", default: true)
     var continuous: Bool
     
     @Parameter(title: "message", requestValueDialog: IntentDialog("chat"))


### PR DESCRIPTION
- Removed the system prompt for non-continuous intent
- Thread now conforms to Sendable (Swift6 warning)
- Added a guard to the load function to prevent crashes if the user's selected model is not available in the app anymore