### PR TITLE
[macOS] Add `Settings…` menu item

### DIFF
--- a/fullmoon/ContentView.swift
+++ b/fullmoon/ContentView.swift
@@ -13,7 +13,6 @@ struct ContentView: View {
     @Environment(\.modelContext) var modelContext
     @Environment(LLMEvaluator.self) var llm
     @State var showOnboarding = false
-    @State var showSettings = false
     @State var showChats = false
     @State var currentThread: Thread?
     @FocusState var isPromptFocused: Bool
@@ -28,11 +27,11 @@ struct ContentView: View {
                     .navigationSplitViewColumnWidth(min: 240, ideal: 240, max: 320)
                     #endif
                 } detail: {
-                    ChatView(currentThread: $currentThread, isPromptFocused: $isPromptFocused, showChats: $showChats, showSettings: $showSettings)
+                    ChatView(currentThread: $currentThread, isPromptFocused: $isPromptFocused, showChats: $showChats)
                 }
             } else {
                 // iPhone
-                ChatView(currentThread: $currentThread, isPromptFocused: $isPromptFocused, showChats: $showChats, showSettings: $showSettings)
+                ChatView(currentThread: $currentThread, isPromptFocused: $isPromptFocused, showChats: $showChats)
             }
         }
         .environmentObject(appManager)
@@ -68,7 +67,10 @@ struct ContentView: View {
                     view.presentationDetents([.medium, .large])
                 }
         }
-        .sheet(isPresented: $showSettings) {
+        .sheet(isPresented: .init(
+            get: { appManager.showSettings },
+            set: { appManager.showSettings = $0 }
+        )) {
             SettingsView(currentThread: $currentThread)
                 .environmentObject(appManager)
                 .environment(llm)

--- a/fullmoon/Models/Data.swift
+++ b/fullmoon/Models/Data.swift
@@ -18,6 +18,7 @@ class AppManager: ObservableObject {
     @AppStorage("shouldPlayHaptics") var shouldPlayHaptics = true
     @AppStorage("numberOfVisits") var numberOfVisits = 0
     @AppStorage("numberOfVisitsOfLastRequest") var numberOfVisitsOfLastRequest = 0
+    @Published var showSettings = false
     
     var userInterfaceIdiom: LayoutType {
         #if os(visionOS)

--- a/fullmoon/Views/Chat/ChatView.swift
+++ b/fullmoon/Views/Chat/ChatView.swift
@@ -18,7 +18,6 @@ struct ChatView: View {
     @State var prompt = ""
     @FocusState.Binding var isPromptFocused: Bool
     @Binding var showChats: Bool
-    @Binding var showSettings: Bool
     
     @State var thinkingTime: TimeInterval?
     
@@ -247,7 +246,7 @@ struct ChatView: View {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(action: {
                             appManager.playHaptic()
-                            showSettings.toggle()
+                            appManager.showSettings.toggle()
                         }) {
                             Image(systemName: "gear")
                         }
@@ -256,7 +255,7 @@ struct ChatView: View {
                     ToolbarItem(placement: .primaryAction) {
                         Button(action: {
                             appManager.playHaptic()
-                            showSettings.toggle()
+                            appManager.showSettings.toggle()
                         }) {
                             Label("settings", systemImage: "gear")
                         }
@@ -313,5 +312,5 @@ struct ChatView: View {
 
 #Preview {
     @FocusState var isPromptFocused: Bool
-    ChatView(currentThread: .constant(nil), isPromptFocused: $isPromptFocused, showChats: .constant(false), showSettings: .constant(false))
+    ChatView(currentThread: .constant(nil), isPromptFocused: $isPromptFocused, showChats: .constant(false))
 }

--- a/fullmoon/fullmoonApp.swift
+++ b/fullmoon/fullmoonApp.swift
@@ -44,6 +44,13 @@ struct fullmoonApp: App {
                     }
                 }
             }
+            
+            CommandGroup(after: .appSettings) {
+                Button("Settings…") {
+                    appManager.showSettings = true
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
         }
         #endif
     }


### PR DESCRIPTION
## Description

Adds the standard `Settings…` menu item for presenting the Settings menu when using the app on macOS, along with the standard `⌘,` keyboard shortcut.

![Screenshot 2025-01-24 at 1 04 35 PM](https://github.com/user-attachments/assets/d2ef1945-b1a4-4d3b-b912-79b669a5b2ba)
