### PR TITLE
[macOS] Add content width preference options

### DIFF
--- a/fullmoon/Models/Data.swift
+++ b/fullmoon/Models/Data.swift
@@ -18,6 +18,7 @@ class AppManager: ObservableObject {
     @AppStorage("shouldPlayHaptics") var shouldPlayHaptics = true
     @AppStorage("numberOfVisits") var numberOfVisits = 0
     @AppStorage("numberOfVisitsOfLastRequest") var numberOfVisitsOfLastRequest = 0
+    @AppStorage("appContentWidth") var appContentWidth: AppContentWidth = .fill
     
     var userInterfaceIdiom: LayoutType {
         #if os(visionOS)
@@ -254,6 +255,19 @@ enum AppFontSize: String, CaseIterable {
             .large
         case .xlarge:
             .xLarge
+        }
+    }
+}
+
+enum AppContentWidth: String, CaseIterable {
+    case narrow, fill
+    
+    func getMaxWidth() -> CGFloat? {
+        switch self {
+        case .narrow:
+            return 640
+        case .fill:
+            return nil
         }
     }
 }

--- a/fullmoon/Views/Chat/ConversationView.swift
+++ b/fullmoon/Views/Chat/ConversationView.swift
@@ -185,29 +185,36 @@ struct ConversationView: View {
     var body: some View {
         ScrollViewReader { scrollView in
             ScrollView(.vertical) {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(thread.sortedMessages) { message in
-                        MessageView(message: message)
+                HStack {
+                    Spacer(minLength: 0)
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(thread.sortedMessages) { message in
+                            MessageView(message: message)
+                                .padding()
+                                .id(message.id.uuidString)
+                        }
+
+                        if llm.running && !llm.output.isEmpty && thread.id == generatingThreadID {
+                            VStack {
+                                MessageView(message: Message(role: .assistant, content: llm.output + " 🌕"))
+                            }
                             .padding()
-                            .id(message.id.uuidString)
-                    }
-
-                    if llm.running && !llm.output.isEmpty && thread.id == generatingThreadID {
-                        VStack {
-                            MessageView(message: Message(role: .assistant, content: llm.output + " 🌕"))
+                            .id("output")
+                            .onAppear {
+                                print("output appeared")
+                                scrollInterrupted = false // reset interruption when a new output begins
+                            }
                         }
-                        .padding()
-                        .id("output")
-                        .onAppear {
-                            print("output appeared")
-                            scrollInterrupted = false // reset interruption when a new output begins
-                        }
-                    }
 
-                    Rectangle()
-                        .fill(.clear)
-                        .frame(height: 1)
-                        .id("bottom")
+                        Rectangle()
+                            .fill(.clear)
+                            .frame(height: 1)
+                            .id("bottom")
+                    }
+                    #if os(macOS)
+                    .frame(maxWidth: appManager.appContentWidth.getMaxWidth())
+                    #endif
+                    Spacer(minLength: 0)
                 }
                 .scrollTargetLayout()
             }

--- a/fullmoon/Views/Settings/AppearanceSettingsView.swift
+++ b/fullmoon/Views/Settings/AppearanceSettingsView.swift
@@ -56,6 +56,19 @@ struct AppearanceSettingsView: View {
                 }
                 #endif
             }
+
+            #if os(macOS)
+            Section(header: Text("layout")) {
+                Picker(selection: $appManager.appContentWidth) {
+                    ForEach(AppContentWidth.allCases.sorted(by: { $0.rawValue < $1.rawValue }), id: \.rawValue) { option in
+                        Text(String(describing: option).lowercased())
+                            .tag(option)
+                    }
+                } label: {
+                    Label("content width", systemImage: "macwindow")
+                }
+            }
+            #endif
         }
         .formStyle(.grouped)
         .navigationTitle("appearance")


### PR DESCRIPTION
## Description

- Adds a new appearance menu option to set the content width of the conversation window on macOS only
  - `fill`: this is the existing layout and remains the default
  - `narrow`: new display option which limits the width of the conversation content width to 640pt

## Screenshots

![Screenshot 2025-01-24 at 1 19 54 PM](https://github.com/user-attachments/assets/7edae210-f3a9-4ab0-80c7-65b040c98a03)

![Screenshot 2025-01-24 at 1 19 59 PM](https://github.com/user-attachments/assets/f3047c1b-5efd-47b0-a51c-4b8aad145c3f)

![Screenshot 2025-01-24 at 1 19 59 PM](https://github.com/user-attachments/assets/7dfcf1fb-2e69-4767-91fb-bb159f2dbe4e)
