### PR TITLE
[Suggestion] Font settings tweaks

### DIFF
--- a/fullmoon/ContentView.swift
+++ b/fullmoon/ContentView.swift
@@ -86,7 +86,7 @@ struct ContentView: View {
         #if !os(visionOS)
         .tint(appManager.appTintColor.getColor())
         #endif
-        .fontDesign(appManager.appFontDesign.getFontDesign())
+        .fontDesign(appManager.appFontFamily.getFontDesign())
         .environment(\.dynamicTypeSize, appManager.appFontSize.getFontSize())
         .fontWidth(appManager.appFontWidth.getFontWidth())
         .onAppear {

--- a/fullmoon/Models/Data.swift
+++ b/fullmoon/Models/Data.swift
@@ -11,7 +11,7 @@ import SwiftData
 class AppManager: ObservableObject {
     @AppStorage("systemPrompt") var systemPrompt = "you are a helpful assistant"
     @AppStorage("appTintColor") var appTintColor: AppTintColor = .monochrome
-    @AppStorage("appFontDesign") var appFontDesign: AppFontDesign = .standard
+    @AppStorage("appFontFamily") var appFontFamily: AppFontFamily = .sansSerif
     @AppStorage("appFontSize") var appFontSize: AppFontSize = .medium
     @AppStorage("appFontWidth") var appFontWidth: AppFontWidth = .standard
     @AppStorage("currentModelName") var currentModelName: String?
@@ -205,12 +205,12 @@ enum AppTintColor: String, CaseIterable {
     }
 }
 
-enum AppFontDesign: String, CaseIterable {
-    case standard, monospaced, rounded, serif
+enum AppFontFamily: String, CaseIterable {
+    case sansSerif, monospaced, rounded, serif
     
     func getFontDesign() -> Font.Design {
         switch self {
-        case .standard:
+        case .sansSerif:
             .default
         case .monospaced:
             .monospaced

--- a/fullmoon/Views/Settings/AppearanceSettingsView.swift
+++ b/fullmoon/Views/Settings/AppearanceSettingsView.swift
@@ -26,24 +26,25 @@ struct AppearanceSettingsView: View {
             #endif
 
             Section(header: Text("font")) {
-                Picker(selection: $appManager.appFontDesign) {
-                    ForEach(AppFontDesign.allCases.sorted(by: { $0.rawValue < $1.rawValue }), id: \.rawValue) { option in
-                        Text(String(describing: option).lowercased())
+                Picker(selection: $appManager.appFontFamily) {
+                    ForEach(AppFontFamily.allCases.sorted(by: { $0.rawValue < $1.rawValue }), id: \.rawValue) { option in
+                        Text(option == .sansSerif ? "sans serif" : String(describing: option).lowercased())
                             .tag(option)
                     }
                 } label: {
-                    Label("design", systemImage: "textformat")
+                    Label("family", systemImage: "textformat")
                 }
 
-                Picker(selection: $appManager.appFontWidth) {
-                    ForEach(AppFontWidth.allCases.sorted(by: { $0.rawValue < $1.rawValue }), id: \.rawValue) { option in
-                        Text(String(describing: option).lowercased())
-                            .tag(option)
+                if appManager.appFontFamily == .sansSerif {
+                    Picker(selection: $appManager.appFontWidth) {
+                        ForEach(AppFontWidth.allCases.sorted(by: { $0.rawValue < $1.rawValue }), id: \.rawValue) { option in
+                            Text(String(describing: option).lowercased())
+                                .tag(option)
+                        }
+                    } label: {
+                        Label("width", systemImage: "arrow.left.and.line.vertical.and.arrow.right")
                     }
-                } label: {
-                    Label("width", systemImage: "arrow.left.and.line.vertical.and.arrow.right")
                 }
-                .disabled(appManager.appFontDesign != .standard)
 
                 #if !os(macOS)
                 Picker(selection: $appManager.appFontSize) {


### PR DESCRIPTION
## Description

Suggested tweaks to the font settings:
- Updates the `design` label to `family` as the options are usually referenced as such in design, and may be easier to understand right away
- Updates the `standard` label to `sans serif` to more closely match the other options (monospace, serif, rounded)
- Updates the grouped table view behavior so the `width` row only appears when `sans serif` is selected as those options are only available for the sans serif font. It also reinforces the relationship between that setting and the row above it

## Screen recording

https://github.com/user-attachments/assets/d23dfdad-4555-45a0-a5e6-271851d38f5c
