### PR TITLE
Add ability to rename chat threads

### DIFF
--- a/fullmoon/Views/Chat/ChatListRowView.swift
+++ b/fullmoon/Views/Chat/ChatListRowView.swift
@@ -1,0 +1,81 @@
+//
+//  ChatListRowView.swift
+//  fullmoon
+//
+//  Created by Pedro Diogo on 26/01/2025.
+//
+
+import SwiftUI
+
+struct ChatListRowView: View {
+    @State private var isRenaming: Bool = false
+    @FocusState private var isRenameTextFieldFocused: Bool
+    
+    var thread: Thread
+    var deleteThread: (Thread) -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            ZStack {
+                if isRenaming {
+                    EditTitleTextField
+                } else {
+                    Text(thread.title ?? "untitled").lineLimit(1)
+                }
+            }
+            .foregroundStyle(.primary)
+            .font(.headline)
+            
+            Text("\(thread.timestamp.formatted())")
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+        }
+        #if os(macOS)
+        .swipeActions {
+            Button("Delete") {
+                deleteThread(thread)
+            }
+            .tint(.red)
+        }
+        .contextMenu {
+            Button {
+                deleteThread(thread)
+            } label: {
+                Text("delete")
+            }
+            if !(isRenaming) {
+                Button {
+                    isRenaming = true
+                } label: {
+                    Text("rename")
+                }
+            }
+        }
+        .onTapGesture(count: 2) {
+            isRenaming = true
+        }
+        #endif
+        .tag(thread)
+    }
+    
+    private var EditTitleTextField : some View {
+        TextField("Title", text: Binding(
+            get: { thread.title ?? "" },
+            set: { thread.title = $0 }
+        ))
+        .focused($isRenameTextFieldFocused)
+        .onAppear {
+            isRenameTextFieldFocused = true
+        }
+        .onChange(of: isRenameTextFieldFocused) {
+            if !isRenameTextFieldFocused {
+                isRenaming = false
+            }
+        }
+    }
+        
+}
+
+#Preview {
+    ChatListRowView(thread: Thread(), deleteThread: { _ in })
+}

--- a/fullmoon/Views/Chat/ChatsListView.swift
+++ b/fullmoon/Views/Chat/ChatsListView.swift
@@ -29,38 +29,7 @@ struct ChatsListView: View {
                     Section {} // adds some space below the search bar on mac
                     #endif
                     ForEach(filteredThreads, id: \.id) { thread in
-                        VStack(alignment: .leading) {
-                            ZStack {
-                                if let firstMessage = thread.sortedMessages.first {
-                                    Text(firstMessage.content)
-                                        .lineLimit(1)
-                                } else {
-                                    Text("untitled")
-                                }
-                            }
-                            .foregroundStyle(.primary)
-                            .font(.headline)
-
-                            Text("\(thread.timestamp.formatted())")
-                                .foregroundStyle(.secondary)
-                                .font(.subheadline)
-                        }
-                        #if os(macOS)
-                            .swipeActions {
-                                Button("Delete") {
-                                    deleteThread(thread)
-                                }
-                                .tint(.red)
-                            }
-                            .contextMenu {
-                                Button {
-                                    deleteThread(thread)
-                                } label: {
-                                    Text("delete")
-                                }
-                            }
-                        #endif
-                            .tag(thread)
+                        ChatListRowView(thread: thread, deleteThread: deleteThread)
                     }
                     .onDelete(perform: deleteThreads)
                 }


### PR DESCRIPTION
Adds the ability to rename chat threads:
* In macOS this is possible by right clicking->rename on a chat or double clicking on a chat (default behaviour for renaming things in macOS) in the sidebar.
* In iOS this can be done via the title of the chat in the chat itself.

The behaviour is still the same - the first message is used as the title of the chat. I plan to update that next so the title is generated based on the contents of the chat.

Fixes part of https://github.com/mainframecomputer/fullmoon-ios/issues/66

Also in this PR:
* Extracted part of the ChatListRowView to a new file because I was getting compilation errors as the view was getting too complex

(My first contribution :) )
## UI:
### macOS
https://github.com/user-attachments/assets/82172936-fd72-4ac2-84d5-f1dd9c058cba

### iOS
https://github.com/user-attachments/assets/fea08a05-e35d-4f25-b1d3-4b78cd948d12

