### PR TITLE
Fix model parameter naming inconsistency

### DIFF
--- a/fullmoon/Models/Models.swift
+++ b/fullmoon/Models/Models.swift
@@ -27,7 +27,7 @@ extension ModelConfiguration: @retroactive Equatable {
         return lhs.name == rhs.name
     }
 
-    public static let llama_3_2_1B_4bit = ModelConfiguration(
+    public static let llama_3_2_1b_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-1B-Instruct-4bit"
     )
 
@@ -44,14 +44,14 @@ extension ModelConfiguration: @retroactive Equatable {
     )
 
     public static var availableModels: [ModelConfiguration] = [
-        llama_3_2_1B_4bit,
+        llama_3_2_1b_4bit,
         llama_3_2_3b_4bit,
         deepseek_r1_distill_qwen_1_5b_4bit,
         deepseek_r1_distill_qwen_1_5b_8bit
     ]
 
     public static var defaultModel: ModelConfiguration {
-        llama_3_2_1B_4bit
+        llama_3_2_1b_4bit
     }
 
     public static func getModelByName(_ name: String) -> ModelConfiguration? {
@@ -97,7 +97,7 @@ extension ModelConfiguration: @retroactive Equatable {
     /// Returns the model's approximate size, in GB.
     public var modelSize: Decimal? {
         switch self {
-        case .llama_3_2_1B_4bit: return 0.7
+        case .llama_3_2_1b_4bit: return 0.7
         case .llama_3_2_3b_4bit: return 1.8
         case .deepseek_r1_distill_qwen_1_5b_4bit: return 1.0
         case .deepseek_r1_distill_qwen_1_5b_8bit: return 1.9


### PR DESCRIPTION
Only llama_3_2_1b_4bit was using a uppercase "B" in the variable name while the others were lowercase "b"