### PR TITLE
Compile macOS only for Apple Silicon

### DIFF
--- a/fullmoon.xcodeproj/project.pbxproj
+++ b/fullmoon.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		860E9CE02CB055B100C5BB52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = fullmoon/fullmoon.entitlements;
@@ -325,6 +326,7 @@
 		860E9CE12CB055B100C5BB52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = fullmoon/fullmoon.entitlements;


### PR DESCRIPTION
Since fullmoon doesn't work on Intel anyways, why compile a universal binary.