### PR TITLE
Add Qwen3.5 0.8B and 2B variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [x] [DeepSeek-R1-Distill-Qwen-1.5B-4bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit)
 - [x] [Qwen3.5-0.8B-4bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-4bit)
 - [x] [Qwen3.5-2B-4bit](https://huggingface.co/mlx-community/Qwen3.5-2B-4bit)
+- [x] [Qwen3.5-9B-4bit](https://huggingface.co/mlx-community/Qwen3.5-9B-4bit)
 
 ## credits
 fullmoon is made possible by [MLX Swift](https://github.com/ml-explore/mlx-swift) from Apple. [MLX](https://github.com/ml-explore/mlx) is an array framework for machine learning research on Apple silicon.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - [x] [Llama 3.2 1B](https://huggingface.co/mlx-community/Llama-3.2-1B-Instruct-4bit)
 - [x] [Llama 3.2 3B](https://huggingface.co/mlx-community/Llama-3.2-3B-Instruct-4bit)
 - [x] [DeepSeek-R1-Distill-Qwen-1.5B-4bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit)
+- [x] [Qwen3.5-0.8B-4bit](https://huggingface.co/mlx-community/Qwen3.5-0.8B-4bit)
+- [x] [Qwen3.5-2B-4bit](https://huggingface.co/mlx-community/Qwen3.5-2B-4bit)
 
 ## credits
 fullmoon is made possible by [MLX Swift](https://github.com/ml-explore/mlx-swift) from Apple. [MLX](https://github.com/ml-explore/mlx) is an array framework for machine learning research on Apple silicon.

--- a/fullmoon.xcodeproj/project.pbxproj
+++ b/fullmoon.xcodeproj/project.pbxproj
@@ -131,7 +131,7 @@
 			mainGroup = 860E9CC52CB055B000C5BB52;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
+				860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				860F26A22CBC31D6004E8D40 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				25F645512D4E7A6F0049EFBE /* XCRemoteSwiftPackageReference "swift-transformers" */,
 			);
@@ -401,12 +401,12 @@
 			repositoryURL = "https://github.com/huggingface/swift-transformers.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.17;
+				minimumVersion = 1.1.0;
 			};
 		};
-		860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
+		860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples/";
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
 			requirement = {
 				branch = main;
 				kind = branch;
@@ -435,12 +435,12 @@
 		};
 		869B97612D0DD46B0078DF5A /* MLXLMCommon */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLMCommon;
 		};
 		869B97632D0DD4D80078DF5A /* MLXLLM */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			package = 860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLLM;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/fullmoon.xcodeproj/project.pbxproj
+++ b/fullmoon.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1B2C3D42E9A100100AA55BB /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D52E9A100100AA55BB /* MLXRandom */; };
 		25F645532D4E7A6F0049EFBE /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = 25F645522D4E7A6F0049EFBE /* Transformers */; };
 		860F26A42CBC31D6004E8D40 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 860F26A32CBC31D6004E8D40 /* MarkdownUI */; };
 		869B97622D0DD46B0078DF5A /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 869B97612D0DD46B0078DF5A /* MLXLMCommon */; };
@@ -45,6 +46,7 @@
 			files = (
 				869B97642D0DD4D80078DF5A /* MLXLLM in Frameworks */,
 				869B97622D0DD46B0078DF5A /* MLXLMCommon in Frameworks */,
+				A1B2C3D42E9A100100AA55BB /* MLXRandom in Frameworks */,
 				25F645532D4E7A6F0049EFBE /* Transformers in Frameworks */,
 				860F26A42CBC31D6004E8D40 /* MarkdownUI in Frameworks */,
 			);
@@ -100,6 +102,7 @@
 				860F26A32CBC31D6004E8D40 /* MarkdownUI */,
 				869B97612D0DD46B0078DF5A /* MLXLMCommon */,
 				869B97632D0DD4D80078DF5A /* MLXLLM */,
+				A1B2C3D52E9A100100AA55BB /* MLXRandom */,
 				25F645522D4E7A6F0049EFBE /* Transformers */,
 			);
 			productName = fullmoon;
@@ -132,6 +135,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+				A1B2C3D62E9A100100AA55BB /* XCRemoteSwiftPackageReference "mlx-swift" */,
 				860F26A22CBC31D6004E8D40 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				25F645512D4E7A6F0049EFBE /* XCRemoteSwiftPackageReference "swift-transformers" */,
 			);
@@ -404,6 +408,14 @@
 				minimumVersion = 1.1.0;
 			};
 		};
+		A1B2C3D62E9A100100AA55BB /* XCRemoteSwiftPackageReference "mlx-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.30.6;
+			};
+		};
 		860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
@@ -442,6 +454,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLLM;
+		};
+		A1B2C3D52E9A100100AA55BB /* MLXRandom */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1B2C3D62E9A100100AA55BB /* XCRemoteSwiftPackageReference "mlx-swift" */;
+			productName = MLXRandom;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/fullmoon.xcodeproj/project.pbxproj
+++ b/fullmoon.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		A1B2C3D42E9A100100AA55BB /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D52E9A100100AA55BB /* MLXRandom */; };
-		25F645532D4E7A6F0049EFBE /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = 25F645522D4E7A6F0049EFBE /* Transformers */; };
 		860F26A42CBC31D6004E8D40 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 860F26A32CBC31D6004E8D40 /* MarkdownUI */; };
 		869B97622D0DD46B0078DF5A /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 869B97612D0DD46B0078DF5A /* MLXLMCommon */; };
 		869B97642D0DD4D80078DF5A /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 869B97632D0DD4D80078DF5A /* MLXLLM */; };
@@ -47,7 +46,6 @@
 				869B97642D0DD4D80078DF5A /* MLXLLM in Frameworks */,
 				869B97622D0DD46B0078DF5A /* MLXLMCommon in Frameworks */,
 				A1B2C3D42E9A100100AA55BB /* MLXRandom in Frameworks */,
-				25F645532D4E7A6F0049EFBE /* Transformers in Frameworks */,
 				860F26A42CBC31D6004E8D40 /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -103,7 +101,6 @@
 				869B97612D0DD46B0078DF5A /* MLXLMCommon */,
 				869B97632D0DD4D80078DF5A /* MLXLLM */,
 				A1B2C3D52E9A100100AA55BB /* MLXRandom */,
-				25F645522D4E7A6F0049EFBE /* Transformers */,
 			);
 			productName = fullmoon;
 			productReference = 860E9CCE2CB055B000C5BB52 /* fullmoon.app */;
@@ -137,7 +134,6 @@
 				860E9CE22CB0564600C5BB52 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				A1B2C3D62E9A100100AA55BB /* XCRemoteSwiftPackageReference "mlx-swift" */,
 				860F26A22CBC31D6004E8D40 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
-				25F645512D4E7A6F0049EFBE /* XCRemoteSwiftPackageReference "swift-transformers" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 860E9CCF2CB055B000C5BB52 /* Products */;
@@ -400,14 +396,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		25F645512D4E7A6F0049EFBE /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/huggingface/swift-transformers.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
-			};
-		};
 		A1B2C3D62E9A100100AA55BB /* XCRemoteSwiftPackageReference "mlx-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift";
@@ -435,11 +423,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		25F645522D4E7A6F0049EFBE /* Transformers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 25F645512D4E7A6F0049EFBE /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Transformers;
-		};
 		860F26A32CBC31D6004E8D40 /* MarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 860F26A22CBC31D6004E8D40 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;

--- a/fullmoon/Models/Models.swift
+++ b/fullmoon/Models/Models.swift
@@ -17,6 +17,8 @@ public extension ModelConfiguration {
         switch self {
         case .deepseek_r1_distill_qwen_1_5b_4bit: .reasoning
         case .deepseek_r1_distill_qwen_1_5b_8bit: .reasoning
+        case .qwen_3_5_0_8b_4bit: .reasoning
+        case .qwen_3_5_2b_4bit: .reasoning
         case .qwen_3_4b_4bit: .reasoning
         case .qwen_3_8b_4bit: .reasoning
         default: .regular
@@ -45,6 +47,14 @@ extension ModelConfiguration: @retroactive Equatable {
         id: "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-8bit"
     )
 
+    public static let qwen_3_5_0_8b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.5-0.8B-4bit"
+    )
+
+    public static let qwen_3_5_2b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.5-2B-4bit"
+    )
+
     public static let qwen_3_4b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-4B-4bit"
     )
@@ -58,6 +68,8 @@ extension ModelConfiguration: @retroactive Equatable {
         llama_3_2_3b_4bit,
         deepseek_r1_distill_qwen_1_5b_4bit,
         deepseek_r1_distill_qwen_1_5b_8bit,
+        qwen_3_5_0_8b_4bit,
+        qwen_3_5_2b_4bit,
         qwen_3_4b_4bit,
         qwen_3_8b_4bit,
     ]
@@ -118,6 +130,8 @@ extension ModelConfiguration: @retroactive Equatable {
         case .llama_3_2_3b_4bit: return 1.8
         case .deepseek_r1_distill_qwen_1_5b_4bit: return 1.0
         case .deepseek_r1_distill_qwen_1_5b_8bit: return 1.9
+        case .qwen_3_5_0_8b_4bit: return 0.7
+        case .qwen_3_5_2b_4bit: return 1.8
         case .qwen_3_4b_4bit: return 2.3
         case .qwen_3_8b_4bit: return 4.7
         default: return nil

--- a/fullmoon/Models/Models.swift
+++ b/fullmoon/Models/Models.swift
@@ -19,6 +19,7 @@ public extension ModelConfiguration {
         case .deepseek_r1_distill_qwen_1_5b_8bit: .reasoning
         case .qwen_3_5_0_8b_4bit: .reasoning
         case .qwen_3_5_2b_4bit: .reasoning
+        case .qwen_3_5_9b_4bit: .reasoning
         case .qwen_3_4b_4bit: .reasoning
         case .qwen_3_8b_4bit: .reasoning
         default: .regular
@@ -55,6 +56,10 @@ extension ModelConfiguration: @retroactive Equatable {
         id: "mlx-community/Qwen3.5-2B-4bit"
     )
 
+    public static let qwen_3_5_9b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.5-9B-4bit"
+    )
+
     public static let qwen_3_4b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-4B-4bit"
     )
@@ -70,6 +75,7 @@ extension ModelConfiguration: @retroactive Equatable {
         deepseek_r1_distill_qwen_1_5b_8bit,
         qwen_3_5_0_8b_4bit,
         qwen_3_5_2b_4bit,
+        qwen_3_5_9b_4bit,
         qwen_3_4b_4bit,
         qwen_3_8b_4bit,
     ]
@@ -132,6 +138,7 @@ extension ModelConfiguration: @retroactive Equatable {
         case .deepseek_r1_distill_qwen_1_5b_8bit: return 1.9
         case .qwen_3_5_0_8b_4bit: return 0.7
         case .qwen_3_5_2b_4bit: return 1.8
+        case .qwen_3_5_9b_4bit: return 5.5
         case .qwen_3_4b_4bit: return 2.3
         case .qwen_3_8b_4bit: return 4.7
         default: return nil

--- a/fullmoon/Models/RequestLLMIntent.swift
+++ b/fullmoon/Models/RequestLLMIntent.swift
@@ -91,7 +91,7 @@ struct NewChatShortcut: AppShortcutsProvider {
         AppShortcut(
             intent: RequestLLMIntent(),
             phrases: [
-                "Start a new chat",
+                "Start a new \(.applicationName) chat",
                 "Start a \(.applicationName) chat",
                 "Chat with \(.applicationName)",
                 "Ask \(.applicationName) a question"


### PR DESCRIPTION
Adds two new Qwen3.5 model options to the in-app model catalog: 0.8B 4bit and 2B 4bit. Updates include model definitions, model list wiring, reasoning classification, and memory size metadata used by onboarding filters. README supported-model links are updated to match the new options. This also switches package wiring from mlx-swift-examples to mlx-swift-lm (and aligns swift-transformers to 1.1.x) so qwen3_5 model_type is supported at runtime instead of failing with unsupportedModelType.